### PR TITLE
Remap device_id to gpuid

### DIFF
--- a/rpd_tracer/ApiTable.cpp
+++ b/rpd_tracer/ApiTable.cpp
@@ -25,7 +25,6 @@
 #include <deque>
 #include <map>
 
-#include "rpd_tracer.h"
 #include "Utility.h"
 
 

--- a/rpd_tracer/RoctracerDataSource.cpp
+++ b/rpd_tracer/RoctracerDataSource.cpp
@@ -26,7 +26,7 @@
 #include <roctracer_hip.h>
 #include <roctracer_ext.h>
 #include <roctracer_roctx.h>
-#include "hsa/hsa_ext_amd.h"
+#include <hsa/hsa_ext_amd.h>
 
 #include <sqlite3.h>
 #include <fmt/format.h>

--- a/rpd_tracer/rpd_tracer.h
+++ b/rpd_tracer/rpd_tracer.h
@@ -26,6 +26,7 @@ extern "C" {
     void rpdstart();
     void rpdstop();
     void rpdflush();
+    void rpd_mark(const char *domain, const char *apiName, const char* args);
     void rpd_rangePush(const char *domain, const char *apiName, const char* args);
     void rpd_rangePop();
 }


### PR DESCRIPTION
Apply a simple agent to gpuid mapping.  This will give populate rocpd_op with gpu indexes rather than agent indexes (i.e. zero based gpu count).
Still some unsolvable issues when using HIP_VISIBLE_DEVICES and ROCR_VISIBLE_DEVICES with hip device ids.  This will need additional support in hip.