### PR TITLE
Improve rpdTracerControl usage

### DIFF
--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -189,6 +189,9 @@ void Logger::init()
         filename = "./trace.rpd";
     m_filename = filename;
 
+    // Indicate the tracer loaded.  Used for snooping without loading
+    setenv("RPDT_LOADED", "1", 1);
+
     // Create table recorders
 
     m_metadataTable = new MetadataTable(filename);


### PR DESCRIPTION
Change rpsTracerControl api to interact better with loadTracer.sh and be easier to use in general
Added:

- skipCreate() to not initialize the trace file
- skipLoad() to not load the tracer library (only use it if it is already loaded)