### PR TITLE
Add remote start/stop via signal()

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -8,6 +8,7 @@ This is a changelog that describes new features as they are added.  Newest first
 Contents:
 <!-- toc -->
 
+- [Remote Start/stop](#remote-startstop)
 - [Graph Subclass](#graph-subclass)
 - [Pytorch Autograd Subclass](#pytorch-autograd-subclass)
 - [Call Stack Accounting](#call-stack-accounting)
@@ -18,6 +19,31 @@ Contents:
 
 
 --------------------------------------------------------------------------------
+## Remote Start/stop
+Recording can be started and stoped externally through a loader, librpd_remote.so
+
+The loader library is low overhead and can be linked against directly or used with LD_PRELOAD.
+```
+LD_PRELOAD=librpd_remote.so python3
+```
+To record, first create an empty rpd file in the processes' working directory.  The tracer will only append trace data to an existing file, it will not overwrite.
+```
+python rocpd.schema --create trace.rpd
+```
+If in doubt, you can discover this directory before hand by doing a dry run and looking for the zero-length trace file created.  That is the location for the initialized rpd file.
+
+Once the process is running you can use the rpdRemote command to start/stop recording.
+```
+rpdRemote start <pid>
+rpdRemote stop <pid>
+```
+Data is flushed each time the trace is stopped and can be inspected.
+
+Limitations:
+- Once the tracer is loaded, on the first 'start', it can not be unloaded.  There will be a slight increased in overhead.
+- Once loaded, the tracer will record into the same file for the duration.  You can not replace the file on the fly.
+
+
 ## Graph Subclass
 Additional graph analysis is available via a post-processing tool.  This uses graph api calls to identify graph captures, kernels, and subsequent launches.  
 

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,19 @@ all: rpd rocpd
 install:
 	$(MAKE) install -C rocpd_python
 	$(MAKE) install -C rpd_tracer
+	$(MAKE) install -C rpd_remote
 
 .PHONY: uninstall
 uninstall:
 	$(MAKE) uninstall -C rocpd_python
 	$(MAKE) uninstall -C rpd_tracer
+	$(MAKE) uninstall -C rpd_remote
 
 .PHONY: clean
 clean:
 	$(MAKE) clean -C rocpd_python
 	$(MAKE) clean -C rpd_tracer
+	$(MAKE) clean -C rpd_remote
 
 rpd:
 	$(MAKE) -C rpd_tracer
@@ -24,3 +27,5 @@ rpd:
 rocpd:
 	$(MAKE) -c rocpd_python
 
+remote:
+	$(MAKE) -c rpd_remote

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,32 @@
 PYTHON ?= python3
 
 .PHONY:
-all: rpd rocpd
+all: rpd rocpd remote
 
 .PHONY: install
-install:
+install: all
 	$(MAKE) install -C rocpd_python
 	$(MAKE) install -C rpd_tracer
-	$(MAKE) install -C rpd_remote
+	$(MAKE) install -C remote
 
 .PHONY: uninstall
 uninstall:
 	$(MAKE) uninstall -C rocpd_python
 	$(MAKE) uninstall -C rpd_tracer
-	$(MAKE) uninstall -C rpd_remote
+	$(MAKE) uninstall -C remote
 
 .PHONY: clean
 clean:
 	$(MAKE) clean -C rocpd_python
 	$(MAKE) clean -C rpd_tracer
-	$(MAKE) clean -C rpd_remote
+	$(MAKE) clean -C remote
 
+.PHONY: rpd
 rpd:
 	$(MAKE) -C rpd_tracer
-
+.PHONY: rocpd
 rocpd:
-	$(MAKE) -c rocpd_python
-
+	$(MAKE) -C rocpd_python
+.PHONY: remote
 remote:
-	$(MAKE) -c rpd_remote
+	$(MAKE) -C remote 

--- a/remote/Makefile
+++ b/remote/Makefile
@@ -1,0 +1,39 @@
+
+PREFIX = /usr/local
+
+RPD_INCLUDES =
+RPDREMOTE_SRCS = Remote.cpp
+
+
+RPDREMOTE_OBJS = $(RPDREMOTE_SRCS:.cpp=.o)
+
+
+RPDREMOTE_MAIN = librpd_remote.so
+
+
+all: | $(RPDREMOTE_MAIN) 
+
+.PHONY: all 
+
+
+$(RPDREMOTE_MAIN): $(RPDREMOTE_OBJS)
+	$(CXX) -o $@ $^ -shared -rdynamic -std=c++11 -g
+
+.cpp.o:
+	$(CXX) -o $@ -c $< $(RPD_INCLUDES) -std=c++11 -fPIC -g -O3
+
+
+.PHONY: install
+#install: | $(PREFIX)/lib/lib$(RPDREMOTE_MAIN)
+install:
+	cp rpdRemote.sh $(PREFIX)/bin/rpdRemote
+	cp $(RPDREMOTE_MAIN)  $(PREFIX)/lib/
+	ldconfig
+
+.PHONY: uninstall
+uninstall:
+	rm $(PREFIX)/lib/$(RPDREMOTE_MAIN)
+
+.PHONY: clean
+clean:
+	rm -f *.o *.so 

--- a/remote/Makefile
+++ b/remote/Makefile
@@ -11,10 +11,9 @@ RPDREMOTE_OBJS = $(RPDREMOTE_SRCS:.cpp=.o)
 RPDREMOTE_MAIN = librpd_remote.so
 
 
-all: | $(RPDREMOTE_MAIN) 
+all: | $(RPDREMOTE_MAIN)
 
-.PHONY: all 
-
+.PHONY: all
 
 $(RPDREMOTE_MAIN): $(RPDREMOTE_OBJS)
 	$(CXX) -o $@ $^ -shared -rdynamic -std=c++11 -g
@@ -24,8 +23,7 @@ $(RPDREMOTE_MAIN): $(RPDREMOTE_OBJS)
 
 
 .PHONY: install
-#install: | $(PREFIX)/lib/lib$(RPDREMOTE_MAIN)
-install:
+install: all
 	cp rpdRemote.sh $(PREFIX)/bin/rpdRemote
 	cp $(RPDREMOTE_MAIN)  $(PREFIX)/lib/
 	ldconfig
@@ -36,4 +34,4 @@ uninstall:
 
 .PHONY: clean
 clean:
-	rm -f *.o *.so 
+	rm -f *.o *.so

--- a/remote/Remote.cpp
+++ b/remote/Remote.cpp
@@ -1,0 +1,89 @@
+/*********************************************************************************
+* Copyright (c) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+********************************************************************************/
+#include <cstdio>
+#include <dlfcn.h>
+#include <signal.h>
+
+static void remoteInit() __attribute__((constructor));
+
+namespace {
+    bool init = false;
+    int refCount = 0;
+    void (*dl) = nullptr;
+};
+
+void startTracing(int sig);
+void stopTracing(int sig);
+
+void remoteInit()
+{
+    fprintf(stderr, "rpdRemote: init()\n");
+    signal(SIGUSR1, startTracing);
+    signal(SIGUSR2, stopTracing);
+}
+
+void startTracing(int sig)
+{
+    signal(SIGUSR1, startTracing);
+    if (refCount > 0)
+        return;
+    if (dl == nullptr) {
+        dl = dlopen("librpd_tracer.so", RTLD_LAZY);
+    }
+    if (dl) {
+        void (*start_func) (void) = reinterpret_cast<void(*)()>(dlsym(dl, "rpdstart"));
+        if (start_func) {
+            fprintf(stderr, "rpdRemote: tracing started\n");
+            start_func();
+        }
+        else {
+            fprintf(stderr, "rpdRemote: tracing failed\n");
+        }
+    }
+    ++refCount;
+}
+
+void stopTracing(int sig)
+{
+    signal(SIGUSR2, stopTracing);
+    if (refCount > 1)
+        return;
+    if (dl) {
+        void (*stop_func) (void) = reinterpret_cast<void(*)()>(dlsym(dl, "rpdstop"));
+        if (stop_func) {
+            fprintf(stderr, "rpdRemote: tracing stopped\n");
+            stop_func();
+        }
+        void (*flush_func) (void) = reinterpret_cast<void(*)()>(dlsym(dl, "rpdflush"));
+        if (flush_func) {
+            fprintf(stderr, "rpdRemote: trace flushed\n");
+            flush_func();
+        }
+        // FIXME unloading is tricky, so don't
+#if 0
+        int ret = dlclose(dl);
+        if (ret == 0)
+            dl = nullptr;
+#endif
+        --refCount;
+    }
+}

--- a/remote/rpdRemote.sh
+++ b/remote/rpdRemote.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+################################################################################
+# Copyright (c) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+################################################################################
+
+usage()
+{
+    echo "Usage: $0 <start | stop> <pid>"
+    exit 1
+}
+
+if [ $# -ne 2 ] ; then
+    usage
+fi
+
+if [ "$1" = "start" ] ; then
+    kill -s SIGUSR1 $2
+elif [ "$1" = "stop" ] ; then
+    kill -s SIGUSR2 $2
+else
+    usage
+fi

--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -136,6 +136,7 @@ void Logger::rpdflush()
     m_copyApiTable->flush();
     m_opTable->flush();
     m_apiTable->flush();
+    m_monitorTable->flush();
 
     const timestamp_t cb_end_time = clocktime_ns();
     createOverheadRecord(cb_begin_time, cb_end_time, "rpdflush", "");

--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -53,7 +53,7 @@ $(RPD_MAIN): $(RPD_OBJS)
 
 .PHONY: install
 #install: | $(PREFIX)/lib/lib$(RPD_MAIN)
-install:
+install: all
 	cp $(RPD_MAIN)  $(PREFIX)/lib/
 	cp $(RPD_SCRIPT) $(PREFIX)/bin/
 	ldconfig


### PR DESCRIPTION
Create a loader library, librpd_remote.so, that will load librpd_tracer.so when sent a unix signal
Link against the remote lib, or LD_PRELOAD in a pinch
rpdRemote command can be called to start and stop recording