### PR TITLE
Disable rocmsmi data for now

### DIFF
--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -16,7 +16,7 @@ ifneq (,$(HIP_PATH))
         $(info Building with roctracer)
         RPD_LIBS += -L/opt/rocm/lib -lroctracer64 -lroctx64 -lamdhip64 -lrocm_smi64
         RPD_INCLUDES += -I/opt/rocm/include -I/opt/rocm/include/roctracer -I/opt/rocm/include/hsa
-        RPD_SRCS += RoctracerDataSource.cpp RocmSmiDataSource.cpp
+        RPD_SRCS += RoctracerDataSource.cpp #RocmSmiDataSource.cpp
         RPD_INCLUDES += -D__HIP_PLATFORM_AMD__
 endif
 


### PR DESCRIPTION
The librocm_smi64 is causing shutdown corruption in a few instances, depending on library loading order.
Disable this for now.