### PR TITLE
PR to fix egg based installation on Python 3.12

### DIFF
--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -65,7 +65,7 @@ install: all
 	cp $(RPD_MAIN)  $(PREFIX)/lib/
 	cp $(RPD_SCRIPT) $(PREFIX)/bin/
 	ldconfig
-	$(PYTHON) setup.py install
+	$(PYTHON) -m pip install .
 
 .PHONY: uninstall
 uninstall:

--- a/rpd_tracer/setup.py
+++ b/rpd_tracer/setup.py
@@ -21,10 +21,12 @@
 # THE SOFTWARE.
 ################################################################################
 
-from distutils.core import setup, Extension
+from setuptools import setup
 
-setup (name = 'rpdTracer',
-       version = '1.0',
-       description = 'Tracer control from user code',
-       py_modules = ['rpdTracerControl'],
-       )
+setup(
+    name='rpdTracer',
+    version='1.0',
+    description='Tracer control from user code',
+    py_modules=['rpdTracerControl'],
+    install_requires=[],  # Add any dependencies if needed
+)


### PR DESCRIPTION
This PR fixes the egg based installation error on Python 3.12 by migrating to setup-tools. Egg based installation is deprecated on Python 3.12. 