### PR TITLE
Use correct roctx for roctracer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,4 +211,9 @@ tags
 # Persistent undo
 [._]*.un~
 
+# rpd stuff
+*.rpd
+*.json
+*.o
+
 # End of https://www.gitignore.io/api/vim,python,django

--- a/rpd_tracer/loadTracer.sh
+++ b/rpd_tracer/loadTracer.sh
@@ -40,4 +40,4 @@ fi
 
 export RPDT_FILENAME=${OUTPUT_FILE}
 export RPDT_AUTOSTART=0
-LD_PRELOAD=librpd_tracer.so "$@"
+LD_PRELOAD=libroctx64.so:librpd_tracer.so "$@"

--- a/rpd_tracer/runTracer.sh
+++ b/rpd_tracer/runTracer.sh
@@ -39,4 +39,4 @@ if [ $? != 0 ] ; then
 fi
 
 export RPDT_FILENAME=${OUTPUT_FILE}
-LD_PRELOAD=librpd_tracer.so "$@"
+LD_PRELOAD=libroctx64.so:librpd_tracer.so "$@"


### PR DESCRIPTION
Rocprofv3 adds a second roctx library that does not communicate with libroctracer.
Use LD_PRELOAD to select the correct working library.